### PR TITLE
use pip to install python-cdb inside an uberspace

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Python script will check if user exists, if new password and repeated new passwo
 Dependencies of Python script: python-cdb
 
 Install on your uberspace with
-`easy_install-2.7 python-cdb`
+`pip install python-cdb --user`
 
 
 This script probably could be extended to allow each IP only 5 password changes per day to avoid misuse.


### PR DESCRIPTION
easy_install needs an extra `--prefix` or `--install-dir` parameter to work correctly without root and virtualenv. Pip is happy with just the `--user`-one.